### PR TITLE
add Cut and CutString

### DIFF
--- a/mem.go
+++ b/mem.go
@@ -265,6 +265,28 @@ func NewReader(m RO) *Reader {
 	return &Reader{sr: strings.NewReader(m.str())}
 }
 
+// Cut works like strings.Cut, but takes and returns ROs.
+func Cut(m, sep RO) (before, after RO, found bool) {
+	if i := Index(m, sep); i >= 0 {
+		return m.SliceTo(i), m.SliceFrom(i + sep.Len()), true
+	}
+	return m, S(""), false
+}
+
+func CutPrefix(m, prefix RO) (after RO, found bool) {
+	if !HasPrefix(m, prefix) {
+		return m, false
+	}
+	return m.SliceFrom(prefix.Len()), true
+}
+
+func CutSuffix(m, suffix RO) (before RO, found bool) {
+	if !HasSuffix(m, suffix) {
+		return m, false
+	}
+	return m.SliceTo(m.Len() - suffix.Len()), true
+}
+
 // Reader is like a bytes.Reader or strings.Reader.
 type Reader struct {
 	sr *strings.Reader

--- a/mem_test.go
+++ b/mem_test.go
@@ -66,6 +66,7 @@ func TestRO(t *testing.T) {
 	if string(got) != want {
 		t.Errorf("got %q; want %q", got, want)
 	}
+
 }
 
 func TestAllocs(t *testing.T) {
@@ -103,6 +104,72 @@ func TestStrconv(t *testing.T) {
 	}
 	if i != 1234 {
 		t.Errorf("got %d; want 1234", i)
+	}
+}
+
+var cutTests = []struct {
+	s, sep        string
+	before, after string
+	found         bool
+}{
+	{"abc", "b", "a", "c", true},
+	{"abc", "a", "", "bc", true},
+	{"abc", "c", "ab", "", true},
+	{"abc", "abc", "", "", true},
+	{"abc", "", "", "abc", true},
+	{"abc", "d", "abc", "", false},
+	{"", "d", "", "", false},
+	{"", "", "", "", true},
+}
+
+func TestCut(t *testing.T) {
+	for _, tt := range cutTests {
+		if before, after, found := Cut(S(tt.s), S(tt.sep)); !before.Equal(S(tt.before)) || !after.Equal(S(tt.after)) || found != tt.found {
+			t.Errorf("Cut(%q, %q) = %q, %q, %v, want %q, %q, %v", tt.s, tt.sep, before.StringCopy(), after.StringCopy(), found, tt.before, tt.after, tt.found)
+		}
+	}
+}
+
+var cutPrefixTests = []struct {
+	s, sep string
+	after  string
+	found  bool
+}{
+	{"abc", "a", "bc", true},
+	{"abc", "abc", "", true},
+	{"abc", "", "abc", true},
+	{"abc", "d", "abc", false},
+	{"", "d", "", false},
+	{"", "", "", true},
+}
+
+func TestCutPrefix(t *testing.T) {
+	for _, tt := range cutPrefixTests {
+		s, sep := S(tt.s), S(tt.sep)
+		if after, found := CutPrefix(s, sep); !after.Equal(S(tt.after)) || found != tt.found {
+			t.Errorf("CutPrefix(%q, %q) = %q, %v, want %q, %v", tt.s, tt.sep, after.StringCopy(), found, tt.after, tt.found)
+		}
+	}
+}
+
+var cutSuffixTests = []struct {
+	s, sep string
+	after  string
+	found  bool
+}{
+	{"abc", "bc", "a", true},
+	{"abc", "abc", "", true},
+	{"abc", "", "abc", true},
+	{"abc", "d", "abc", false},
+	{"", "d", "", false},
+	{"", "", "", true},
+}
+
+func TestCutSuffix(t *testing.T) {
+	for _, tt := range cutSuffixTests {
+		if after, found := CutSuffix(S(tt.s), S(tt.sep)); !after.Equal(S(tt.after)) || found != tt.found {
+			t.Errorf("CutSuffix(%q, %q) = %q, %v, want %q, %v", tt.s, tt.sep, after.StringCopy(), found, tt.after, tt.found)
+		}
 	}
 }
 


### PR DESCRIPTION
I found myself wanting `Cut` in mem, so I added it and its friends `CutPrefix` and `CutSuffix`.

NOTE: This is implemented without using `strings.Cut` to prevent the need for a minimum Go version bump.

I considered adding `func CutString(m RO, sep string)` for convenience and would be happy to bring it back if it would be welcomed in this PR, or a follow-up PR.

I would appreciate any feedback.